### PR TITLE
[LTB-58] remove Universum dependency

### DIFF
--- a/co-log-sys.cabal
+++ b/co-log-sys.cabal
@@ -1,5 +1,5 @@
 name:           co-log-sys
-version:        0.1.1.0
+version:        0.1.1.1
 synopsis:       Syslog implementation on top of 'co-log-core'
 description:    Please see the README on GitHub at <https://github.com/serokell/co-log-sys#readme>
 category:       Logging
@@ -31,7 +31,7 @@ library
       Paths_co_log_sys
   hs-source-dirs:
       src
-  default-extensions: ApplicativeDo BangPatterns FlexibleContexts LambdaCase MultiWayIf NegativeLiterals OverloadedLabels OverloadedStrings PatternSynonyms PolyKinds RankNTypes RecordWildCards RecursiveDo StandaloneDeriving TupleSections NoImplicitPrelude
+  default-extensions: ApplicativeDo BangPatterns FlexibleContexts LambdaCase MultiWayIf NegativeLiterals OverloadedLabels OverloadedStrings PatternSynonyms PolyKinds RankNTypes RecordWildCards RecursiveDo StandaloneDeriving TupleSections
   ghc-options: -Weverything -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-safe -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-implicit-prelude -Wno-orphans
   build-depends:
       aeson
@@ -42,7 +42,7 @@ library
     , monad-control
     , mtl
     , network
-    , universum
+    , text
     , unix
   default-language: Haskell2010
 
@@ -53,7 +53,7 @@ test-suite co-log-sys-test
       Paths_co_log_sys
   hs-source-dirs:
       test
-  default-extensions: ApplicativeDo BangPatterns FlexibleContexts LambdaCase MultiWayIf NegativeLiterals OverloadedLabels OverloadedStrings PatternSynonyms PolyKinds RankNTypes RecordWildCards RecursiveDo StandaloneDeriving TupleSections NoImplicitPrelude
+  default-extensions: ApplicativeDo BangPatterns FlexibleContexts LambdaCase MultiWayIf NegativeLiterals OverloadedLabels OverloadedStrings PatternSynonyms PolyKinds RankNTypes RecordWildCards RecursiveDo StandaloneDeriving TupleSections
   ghc-options: -Weverything -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-safe -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-implicit-prelude -Wno-orphans -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       aeson
@@ -65,6 +65,6 @@ test-suite co-log-sys-test
     , monad-control
     , mtl
     , network
-    , universum
+    , text
     , unix
   default-language: Haskell2010

--- a/src/Colog/Syslog/Actions.hs
+++ b/src/Colog/Syslog/Actions.hs
@@ -4,13 +4,13 @@ module Colog.Syslog.Actions
        , withLogMessageSyslogGeneric
        ) where
 
-import Universum
-
 import Colog.Core.Action (LogAction (..))
 
 import Colog.Syslog.Config
-import Colog.Syslog.Handler 
+import Colog.Syslog.Handler
 import Colog.Syslog.Message
+
+import Control.Monad.IO.Class
 
 import Control.Monad.Trans.Control (MonadBaseControl)
 

--- a/src/Colog/Syslog/Config.hs
+++ b/src/Colog/Syslog/Config.hs
@@ -9,14 +9,14 @@ module Colog.Syslog.Config
        , PortNumber
        ) where
 
-import Universum
-
 import Colog.Syslog.Priority (Facility (..))
 
 import Data.Aeson (FromJSON(..), ToJSON(..), Value (..), withText, withObject,
     withScientific, (.:), (.:?), (.!=), (.=), object)
+import Data.Text (Text, pack, unpack)
 import Fmt ((+|), (|+))
 import Network.Socket (Family (..), HostName, PortNumber)
+import Text.Read (readMaybe)
 
 -- | Configuration for Syslog
 data SyslogConfig = SyslogConfig
@@ -81,10 +81,10 @@ instance ToJSON Collector where
 -- Orphan Instances
 instance FromJSON Family where
     parseJSON = withText "Family" $ \t ->
-        maybe (fail $ "Unknown Family: \""+|t|+"\"") pure . readMaybe $ toString t
+        maybe (fail $ "Unknown Family: \""+|t|+"\"") pure . readMaybe $ unpack t
 
 instance ToJSON Family where
-    toJSON = String . show
+    toJSON = String . pack . show
 
 instance FromJSON PortNumber where
     parseJSON = withScientific "PortNumber" $ pure . round

--- a/src/Colog/Syslog/Handler.hs
+++ b/src/Colog/Syslog/Handler.hs
@@ -6,15 +6,17 @@ module Colog.Syslog.Handler
        , logSyslogMessage
        ) where
 
-import Universum
-
 import Colog.Core.Action (LogAction (..))
 
 import Colog.Syslog.Config (SyslogConfig (..), Collector (..))
 import Colog.Syslog.Message (Message (..))
 import Colog.Syslog.Priority (Priority (..))
 
-import Control.Exception (IOException)
+import Control.Exception (IOException, bracket, try)
+import Control.Monad (void)
+import Control.Monad.IO.Class
+import Data.Text (Text)
+import Data.Text.Encoding (encodeUtf8)
 import Network.Socket hiding (send, sendTo, recv, recvFrom)
 import Network.Socket.ByteString
 import System.Info (os)

--- a/src/Colog/Syslog/Message.hs
+++ b/src/Colog/Syslog/Message.hs
@@ -8,10 +8,9 @@ module Colog.Syslog.Message
        , fmtMessageFlat
        ) where
 
-import Universum
-
 import Colog.Syslog.Priority (Severity(..))
 
+import Data.Text (Text)
 import Fmt ((|+), (|++|))
 import Lens.Micro (Lens', lens)
 

--- a/src/Colog/Syslog/Priority.hs
+++ b/src/Colog/Syslog/Priority.hs
@@ -10,13 +10,12 @@ module Colog.Syslog.Priority
        , facilityCode
        ) where
 
-import Universum
-
 import Data.Aeson (FromJSON(..), ToJSON(..), Value (..), withText, withObject,
     (.:), (.=), object)
 import Data.Bits ((.|.), shiftL)
+import Data.Text (pack, unpack)
 import Fmt (Buildable (build), fmt, (+|), (|+))
-import Text.Show (Show (show))
+import Text.Read (readMaybe)
 
 -- | Represents the priority of a syslog message, as per RFC5424
 data Priority = Priority Facility Severity
@@ -75,10 +74,10 @@ instance Buildable Severity where
 
 instance FromJSON Severity where
     parseJSON = withText "Severity" $ \t ->
-        maybe (fail $ "Unknown Severity: \""+|t|+"\"") pure . readMaybe $ toString t
+        maybe (fail $ "Unknown Severity: \""+|t|+"\"") pure . readMaybe $ unpack t
 
 instance ToJSON Severity where
-    toJSON = String . Universum.show
+    toJSON = String . pack . show
 
 -- | Numerical code for a 'Severity'. Used to calculate the 'priorityValue'.
 severityCode :: Severity -> Int
@@ -115,10 +114,10 @@ data Facility
 
 instance FromJSON Facility where
     parseJSON = withText "Facility" $ \t ->
-        maybe (fail $ "Unknown Facility: \""+|t|+"\"") pure . readMaybe $ toString t
+        maybe (fail $ "Unknown Facility: \""+|t|+"\"") pure . readMaybe $ unpack t
 
 instance ToJSON Facility where
-    toJSON = String . Universum.show
+    toJSON = String . pack . show
 
 -- | Numerical code for a 'Facility'. Used to calculate the 'priorityValue'.
 facilityCode :: Facility -> Int

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,8 @@ packages:
 - .
 
 extra-deps:
-- universum-1.5.0
+- text-1.2.4.0
+- transformers-0.5.6.2
 
 # Required by co-log-core
 - contravariant-1.5


### PR DESCRIPTION
**Description:**

`co-log-sys` is a fairly straightforward library and does not really need to depend on Universum. As such we can remove `universum` from its dependencies.


**Checklist:**

- [x] Updated docs if necessary
- [x] My code complies with the [style guide](docs/code-style.md)
- [x] Tested my changes if they modify code
